### PR TITLE
#UP9-1 Create MockAPI

### DIFF
--- a/src/hooks/useGetRequests.js
+++ b/src/hooks/useGetRequests.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+export default function useGetRequests(url) {
+  const [ data, setData ] = useState()
+  const [ error, setError ] = useState()
+  const [ loading, setLoading ] = useState( false )
+
+  async function fetchData() {
+    setLoading(true);
+    setError();
+    const payload = await fetch(url)
+      .then(res => res.json())
+      .catch(err => {
+        setError(err);
+      });
+    setData(payload);
+    setLoading(false);
+  }
+
+  useEffect( () => {
+    fetchData();
+  }, [] );
+
+  return {
+    fetchData,
+    data,
+    error,
+    loading,
+  }
+}

--- a/src/mockAPI/initialData.json
+++ b/src/mockAPI/initialData.json
@@ -1,0 +1,69 @@
+{
+  "general": {
+    "insertionsCount": 643  
+  },
+  "charts": {
+    "general": {
+      "followersCount": 9401
+    },
+    "ratingsByCategory": {
+      "followersCount": 3900
+    }
+  },
+  "terms": [
+    85.08,
+    1.76,
+    33.42,
+    75.11
+  ],
+  "supportRequests": [
+    {
+      "name": "Cecilia Welch",
+      "email": "heather_keeling@gottlieb.ca",
+      "timestamp": "2012-04-23T01:06:43.511Z",
+      "phoneNumber": "215-293-5846",
+      "city": "Southe Mariane",
+      "status": "send"
+    },
+    {
+      "name": "Sara Glover",
+      "email": "floyd_brakus@lindgren.com",
+      "timestamp": "2012-04-23T00:22:43.511Z",
+      "phoneNumber": "057-812-3947",
+      "city": "East Maryam",
+      "status": "send"
+    },
+    {
+      "name": "Harriett Morgan",
+      "email": "jabari.kilback@nelson.tv",
+      "timestamp": "2012-04-23T12:22:43.511Z",
+      "phoneNumber": "866-668-0327",
+      "city": "Monserratmouth",
+      "status": "send"
+    },
+    {
+      "name": "Susie Curry",
+      "email": "theo_gleichner@kaia.org",
+      "timestamp": "2012-04-23T07:56:43.511Z",
+      "phoneNumber": "647-851-5280",
+      "city": "Lonnyburgh",
+      "status": "send"
+    },
+    {
+      "name": "Edgar Greer",
+      "email": "ankunding_ralph@gmail.com",
+      "timestamp": "2012-04-23T08:35:43.511Z",
+      "phoneNumber": "985-747-0063",
+      "city": "Schmittfurt",
+      "status": "unsend"
+    },
+    {
+      "name": "Minerva Massey",
+      "email": "lia_purdy@yahoo.com",
+      "timestamp": "2012-04-23T03:24:43.511Z",
+      "phoneNumber": "488-514-5012",
+      "city": "South Lori",
+      "status": "unsend"
+    }
+  ]
+}

--- a/src/mockAPI/patchRequest.js
+++ b/src/mockAPI/patchRequest.js
@@ -1,0 +1,10 @@
+export async function patch(url, body) {
+  await fetch(`${url}/${body.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  })
+    .then(res => res.json())
+    .catch(err => {
+      return err;
+    })
+};

--- a/src/mockAPI/postRequest.js
+++ b/src/mockAPI/postRequest.js
@@ -1,0 +1,10 @@
+export async function post(url, body) {
+  await fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+    .then(res => res.json())
+    .catch(err => {
+      return err;
+    })
+};

--- a/src/mockAPI/server.js
+++ b/src/mockAPI/server.js
@@ -1,0 +1,52 @@
+import { createServer, Model } from 'miragejs';
+import initialData from './initialData';
+
+export function makeServer() {
+  let server = createServer({
+    models: {
+      requests: Model,
+      terms: Model,
+      charts: Model,
+      insertions: Model,
+    },
+    seeds(server) {
+      initialData.supportRequests.forEach(item => {
+        server.create('request', item);
+      });
+      initialData.terms.forEach((item) => {
+        server.create('term', { term: item });
+      });
+      server.create('chart', initialData.charts);
+      server.create('insertion', initialData.general);
+    },
+    routes() {
+      this.get('/api/requests', (schema, request) => {
+        return schema.requests.all();
+      });
+      this.get('/api/requests/quantity', (schema, request) => {
+        return schema.requests.all().length;
+      });
+      this.post('/api/requests', (schema, request) => {
+        let attrs = JSON.parse(request.requestBody);
+        attrs.name = `${attrs.name} ${Math.random().toFixed(2)}`
+        return schema.requests.create(attrs);
+      });
+      this.patch('/api/requests/:id', (schema, request) => {
+        let newAttrs = JSON.parse(request.requestBody);
+        let id = request.params.id;
+        let supportRequest = schema.requests.find(id);
+        return supportRequest.update(newAttrs);
+      });
+      this.get('/api/terms', (schema, request) => {
+        return schema.terms.all();
+      });
+      this.get('/api/charts', (schema, request) => {
+        return schema.charts.all();
+      });
+      this.get('/api/insertions', (schema, request) => {
+        return schema.insertions.all();
+      });
+    },
+  });
+  return server;
+}


### PR DESCRIPTION
This pull request is for creating a mock API for handling the initial data.

To achieve this, we needed to:
- Find a mock API to use in the frontend (the choice was MirageJS).
- Start the "API" with the initial data provided by a .json file.
- Create routes that allow the front end to make GET, POST, and PATCH requests.