### PR TITLE
#UP9-1 Messages Page displaying support requests' messages

### DIFF
--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -1,14 +1,24 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux'
+import store from '../../store'
 import App from '.';
 
 test('renders Premium button', () => {
-  render(<App />);
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
   const linkElement = screen.getByText(/Premium/i);
   expect(linkElement).toBeInTheDocument();
 });
 
 test('renders Data overview title', () => {
-  render(<App />);
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
   const overviewTitle = screen.getByText(/Data overview/i);
   expect(overviewTitle).toBeInTheDocument();
 });

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   BrowserRouter as Router,
   Switch,
   Route,
   Redirect,
 } from "react-router-dom";
-import { Provider } from 'react-redux';
-import store from '../../store/index';
+import { useDispatch, useSelector } from 'react-redux';
+import { seedStore } from '../../store/actions/supportRequestsActions';
+import useGetRequests from '../../hooks/useGetRequests';
 import AppContainer from './styledComponents';
 import Sidebar from '../Sidebar';
 import MainHeader from '../MainHeader';
@@ -17,35 +18,43 @@ import Settings from '../../pages/Settings';
 import Files from '../../pages/Files';
 
 function App() {
+  const { data } = useGetRequests('/api/requests');
+  const supportRequests = useSelector(state => state.data.supportRequests);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if ( data && !supportRequests ) {
+      seedStore(data, dispatch);
+    }
+  }, [data, dispatch, supportRequests]);
+
   return (
-    <Provider store={store}>
-      <Router>
-        <MainHeader />
-        <Sidebar />
-        <AppContainer>
-          <Switch>
-            <Route exact path="/">
-              <Redirect to="/overview" />
-            </Route>
-            <Route path="/overview">
-              <DataOverview />
-            </Route>
-            <Route path="/chat">
-              <Chat />
-            </Route>
-            <Route path="/settings">
-              <Settings />
-            </Route>
-            <Route path="/files">
-              <Files />
-            </Route>
-            <Route path="/message">
-              <Messages />
-            </Route>
-          </Switch>
-        </AppContainer>
-      </Router>
-    </Provider>
+    <Router>
+      <MainHeader />
+      <Sidebar />
+      <AppContainer>
+        <Switch>
+          <Route exact path="/">
+            <Redirect to="/overview" />
+          </Route>
+          <Route path="/overview">
+            <DataOverview />
+          </Route>
+          <Route path="/chat">
+            <Chat />
+          </Route>
+          <Route path="/settings">
+            <Settings />
+          </Route>
+          <Route path="/files">
+            <Files />
+          </Route>
+          <Route path="/message">
+            <Messages />
+          </Route>
+        </Switch>
+      </AppContainer>
+    </Router>
   );
 }
 

--- a/src/components/List/List.test.js
+++ b/src/components/List/List.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import List from '.';
+
+test('renders component with given data', () => {
+  const data = [
+    { name: 'Test', message: { text: 'This is a message' }}
+  ];
+  render(
+    <List data={data} />
+  );
+
+  const linkElement = screen.getByText(/This is a message/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ListWrapper from './styledComponents';
+
+function List({ data }) {
+  return (
+    <ListWrapper>
+      {
+        data && data.map(item => (
+          <li
+            key={item.name}
+            className="message"
+          >
+            <header className="message-sender">
+              {item.name}
+            </header>
+            <p className="message-content">
+              {item.message.text}
+            </p>
+          </li>
+        ))
+      }
+    </ListWrapper>
+  );
+}
+
+export default List;

--- a/src/components/List/styledComponents/index.js
+++ b/src/components/List/styledComponents/index.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+const ListWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+
+  .message {
+    background-color: #e7e9eb;
+    border: 0.5px solid #e0e2e6;
+    border-radius: 3px;
+    margin: 10px 0;
+    width: 100%;
+
+    .message-sender {
+      background-color: #FFFFFF;
+      border-radius: 3px;
+      padding: 10px;
+    }
+
+    .message-content {
+      font-size: 16px;
+      padding: 10px;
+    }
+  }
+`;
+
+export default ListWrapper;

--- a/src/components/Results/index.js
+++ b/src/components/Results/index.js
@@ -16,7 +16,9 @@ function Results({
 
   if (loading) {
     return (
-      <span>Loading...</span>
+      <ResultsWrapper>
+        <span className="loading">Loading...</span>
+      </ResultsWrapper>
     )
   }
 

--- a/src/components/Results/styledComponents/index.js
+++ b/src/components/Results/styledComponents/index.js
@@ -5,12 +5,20 @@ const ResultsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  min-height: 187px;
   padding: 24px;
+  position: relative;
   margin: 0;
   width: 100%;
 
   @media (max-device-width: 768px) {
     padding: 24px 0;
+  }
+
+  .loading {
+    position: absolute;
+    left: 50%;
+    top: 50%;
   }
 
   .result-charts-title {

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -41,7 +41,7 @@ function Table({
                   {Object.entries(row).map((key) => {
                     const className = `td-${key[0]}`;
 
-                    if (key[0] === 'id') return;
+                    if (key[0] === 'id' || typeof key[1] === 'object') return;
 
                     if (isDate(key[1])) {
                       return (

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './components/App';
 import reportWebVitals from './reportWebVitals';
 import { makeServer } from './mockAPI/server';
+import store from './store';
 
 makeServer();
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/mockAPI/server.js
+++ b/src/mockAPI/server.js
@@ -11,6 +11,9 @@ export function makeServer() {
     },
     seeds(server) {
       initialData.supportRequests.forEach(item => {
+        item.message = {
+          text: `This is a message from ${item.name}`
+        };
         server.create('request', item);
       });
       initialData.terms.forEach((item) => {
@@ -29,6 +32,9 @@ export function makeServer() {
       this.post('/api/requests', (schema, request) => {
         let attrs = JSON.parse(request.requestBody);
         attrs.name = `${attrs.name} ${Math.random().toFixed(2)}`
+        attrs.message = {
+          text: `This is a message from ${attrs.name}`
+        };
         return schema.requests.create(attrs);
       });
       this.patch('/api/requests/:id', (schema, request) => {

--- a/src/pages/DataOverview/index.js
+++ b/src/pages/DataOverview/index.js
@@ -1,26 +1,18 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DataOverviewWrapper from './styledComponents';
 import Results from '../../components/Results';
 import Terms from '../../components/Terms';
 import Table from '../../components/Table';
 import Insertions from '../../components/Insertions';
-import useGetRequests from '../../hooks/useGetRequests';
 import { patch } from '../../mockAPI/patchRequest';
 import { post } from '../../mockAPI/postRequest';
-import { seedStore, addSupportRequest, updateSupportRequest } from '../../store/actions/supportRequestsActions';
+import { addSupportRequest, updateSupportRequest } from '../../store/actions/supportRequestsActions';
 
 function DataOverview() {
-  const { data } = useGetRequests('/api/requests');
   const supportRequests = useSelector(state => state.data.supportRequests);
   const dispatch = useDispatch();
   const tableHeader = ['NAME', 'EMAIL', 'TIME', 'PHONE', 'CITY', 'STATUS'];
-
-  useEffect(() => {
-    if ( data && !supportRequests ) {
-      seedStore(data, dispatch);
-    }
-  }, [data, dispatch, supportRequests]);
 
   async function handleStatusChange(item) {
     item.status = item.status === 'send' ? 'unsend' : 'send';

--- a/src/pages/DataOverview/styledComponents/index.js
+++ b/src/pages/DataOverview/styledComponents/index.js
@@ -49,6 +49,7 @@ const DataOverviewWrapper = styled.div`
     display: flex;
     flex-wrap: no-wrap;
     justify-content: space-around;
+    min-height: 187px;
 
     @media (max-device-width: 768px) {
       flex-direction: column;

--- a/src/pages/Messages/index.js
+++ b/src/pages/Messages/index.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import List from '../../components/List';
 
 function Messages() {
+  const requests = useSelector(state => state.data.supportRequests);
+
   return (
     <div>
-      <p>
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-      </p>
+      <List data={requests} />
     </div>
   );
 }


### PR DESCRIPTION
This pull request is intended to create content to the Messages page, to demonstrate what the Flux architecture is useful for in this application. The Messages page now displays messages from support requests, and it's updated globally, not needing to make a new request every time we render this part of the application.

To achieve this, we needed to:
- Create a List component in order to display the messages
- Make data available in the store on the first application render
- Write Unit tests for the new UI component